### PR TITLE
A lot of secboot_tpm changes.

### DIFF
--- a/libstb/secvar/secvar_util.c
+++ b/libstb/secvar/secvar_util.c
@@ -48,15 +48,15 @@ struct secvar_node *new_secvar(char *key, uint64_t key_len, char *data, uint64_t
 	struct secvar_node *ret;
 
 	if (!key)
-		return OPAL_PARAMETER;
+		return NULL;
 	if ((!key_len) || (key_len > SECVAR_MAX_KEY_LEN))
-		return OPAL_PARAMETER;
+		return NULL;
 	if ((!data) && (data_size))
-		return OPAL_PARAMETER;
+		return NULL;
 
 	ret = alloc_secvar(data_size);
 	if (!ret)
-		return OPAL_NO_MEM;
+		return NULL;
 
 	ret->var->key_len = key_len;
 	ret->var->data_size = data_size;

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -345,8 +345,6 @@ static int secboot_tpm_load_bank(struct list_head *bank, int section)
 			return secboot_tpm_load_variable_bank(bank);
 		case SECVAR_UPDATE_BANK:
 			return secboot_load_from_pnor(bank, secboot_image->update, SECBOOT_UPDATE_BANK_SIZE);
-		default:
-			return OPAL_HARDWARE;
 	}
 
 	return OPAL_HARDWARE;

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -185,7 +185,7 @@ static int secboot_tpm_write_variable_bank(struct list_head *bank)
 
 	calc_bank_hash(tpmnv_image->bank_hash[bit], secboot_image->bank[bit], SECBOOT_VARIABLE_BANK_SIZE);
 	// TODO: write an auto-offset calculator
-	rc = tpmnv_ops.write(SECBOOT_TPMNV_INDEX, tpmnv_image->bank_hash[bit], SHA256_DIGEST_LENGTH, ((char *) &tpmnv_image->bank_hash[bit] - (char *) tpmnv_image));
+	rc = tpmnv_ops.write(SECBOOT_TPMNV_INDEX, tpmnv_image->bank_hash[bit], SHA256_DIGEST_LENGTH, offsetof(struct tpmnv, bank_hash[bit]));
 	if (rc)
 		goto out;
 

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -15,7 +15,7 @@
 
 #define CYCLE_BIT(b) (b^0x1)
 
-// Because mbedtls doesn't define this?
+/* Because mbedtls doesn't define this? */
 #define SHA256_DIGEST_LENGTH	32
 
 #define SECBOOT_TPM_MAX_VAR_SIZE	8192

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -172,7 +172,6 @@ static int secboot_tpm_write_variable_bank(struct list_head *bank)
 	uint64_t bit;
 
 	bit = CYCLE_BIT(tpmnv_image->active_bit);
-	// TODO: Write better offset calculation
 	rc = secboot_serialize_bank(bank, tpmnv_image->priority_var, tpmnv_size - offsetof(struct tpmnv, priority_var), SECVAR_FLAG_PRIORITY);
 	if (rc)
 		goto out;
@@ -185,7 +184,6 @@ static int secboot_tpm_write_variable_bank(struct list_head *bank)
 		goto out;
 
 	calc_bank_hash(tpmnv_image->bank_hash[bit], secboot_image->bank[bit], SECBOOT_VARIABLE_BANK_SIZE);
-	// TODO: write an auto-offset calculator
 	rc = tpmnv_ops.write(SECBOOT_TPMNV_INDEX, tpmnv_image->bank_hash[bit], SHA256_DIGEST_LENGTH, offsetof(struct tpmnv, bank_hash[bit]));
 	if (rc)
 		goto out;

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -90,6 +90,7 @@ static int secboot_serialize_bank(struct list_head *bank, char *target, size_t t
 			return OPAL_INTERNAL_ERROR;
 		}
 
+		/* Priority variable is packs the key tightly to save space */
 		if (flags == SECVAR_FLAG_PRIORITY) {
 			memcpy(target, &node->var->key_len, sizeof(node->var->key_len));
 			target += sizeof(node->var->key_len);

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -346,6 +346,7 @@ static int secboot_tpm_store_init(void)
 		goto error;
 	}
 
+	/* TPM needs to be formatted, also reformat SECBOOT with it */
 	if (tpm_first_init) {
 		prlog(PR_INFO, "Initializing and formatting TPMNV space and SECBOOT partition\n");
 		rc = tpmnv_format();

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -27,6 +27,7 @@ extern struct tpmnv_ops_s tpmnv_ops;
 
 const size_t tpmnv_size = 1024;
 
+/* Calculate a SHA256 hash over the supplied buffer */
 static void calc_bank_hash(char *target_hash, char *source_buf, uint64_t size)
 {
 	mbedtls_sha256_context ctx;
@@ -121,7 +122,7 @@ static int secboot_serialize_bank(struct list_head *bank, char *target, size_t t
 	return OPAL_SUCCESS;
 }
 
-
+/* Loads in a flattened list of variables from a buffer into a linked list */
 static int secboot_load_from_pnor(struct list_head *bank, char *source, size_t max_size)
 {
 	char *src;

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -347,6 +347,7 @@ static int secboot_tpm_store_init(void)
 	}
 
 	if (tpm_first_init) {
+		prlog(PR_INFO, "Initializing and formatting TPMNV space and SECBOOT partition\n");
 		rc = tpmnv_format();
 		if (rc)
 			goto error;
@@ -357,7 +358,7 @@ static int secboot_tpm_store_init(void)
 	}
 	/* Determine if we need to reformat just secboot*/
 	else if (secboot_image->header.magic_number != SECBOOT_MAGIC_NUMBER) {
-		prlog(PR_INFO, "Formatting secboot partition...\n");
+		prlog(PR_INFO, "SECBOOT partiton was empty or altered, formatting\n");
 		rc = secboot_format();
 		if (rc) {
 			prlog(PR_ERR, "Failed to format secboot!\n");

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -15,9 +15,6 @@
 
 #define CYCLE_BIT(b) (b^0x1)
 
-/* Because mbedtls doesn't define this? */
-#define SHA256_DIGEST_LENGTH	32
-
 #define SECBOOT_TPM_MAX_VAR_SIZE	8192
 
 struct secboot *secboot_image = NULL;

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -127,6 +127,16 @@ static int secboot_load_from_pnor(struct list_head *bank, char *source, size_t m
 		if (hdr->key_len == 0) {
 			break;
 		}
+		else if (hdr->key_len > SECVAR_MAX_VAR_LEN) {
+			prlog(PR_ERR, "Attempted to load a key larger than max, len = %lld\n", hdr->key_len);
+			return OPAL_INTERNAL_ERROR;
+		}
+
+		if (hdr->data_size > SECBOOT_TPM_MAX_VAR_SIZE) {
+			prlog(PR_ERR, "Attempted to load a data payload larger than max, "
+				      "size = %lld\n", hdr->data_size);
+			return OPAL_INTERNAL_ERROR;
+		}
 
 		tmp = alloc_secvar(hdr->data_size);
 		if (!tmp) {

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -128,14 +128,14 @@ static int secboot_load_from_pnor(struct list_head *bank, char *source, size_t m
 		if (hdr->key_len == 0) {
 			break;
 		}
-		else if (hdr->key_len > SECVAR_MAX_VAR_LEN) {
-			prlog(PR_ERR, "Attempted to load a key larger than max, len = %lld\n", hdr->key_len);
+		else if (hdr->key_len > SECVAR_MAX_KEY_LEN) {
+			prlog(PR_ERR, "Attempted to load a key larger than max, len = %llu\n", hdr->key_len);
 			return OPAL_INTERNAL_ERROR;
 		}
 
 		if (hdr->data_size > SECBOOT_TPM_MAX_VAR_SIZE) {
 			prlog(PR_ERR, "Attempted to load a data payload larger than max, "
-				      "size = %lld\n", hdr->data_size);
+				      "size = %llu\n", hdr->data_size);
 			return OPAL_INTERNAL_ERROR;
 		}
 
@@ -236,7 +236,7 @@ static int secboot_tpm_load_variable_bank(struct list_head *bank)
 	if ((tmp->key_len > SECVAR_MAX_KEY_LEN)
 	     || (tmp->data_size > SECBOOT_TPM_MAX_VAR_SIZE)) {
 		prlog(PR_ERR, "TPM NV Priority variable has impossible sizes, probably internal bug. "
-			      "len = %lld, size = %lld\n", tmp->key_len, tmp->data_size);
+			      "len = %llu, size = %llu\n", tmp->key_len, tmp->data_size);
 		return OPAL_INTERNAL_ERROR;
 	}
 	/* Check if we have a priority variable to load */

--- a/libstb/secvar/storage/secboot_tpm.c
+++ b/libstb/secvar/storage/secboot_tpm.c
@@ -132,7 +132,7 @@ static int secboot_serialize_bank(struct list_head *bank, char *target, size_t t
 			continue;
 
 		/* Priority variable has a different packing scheme */
-		if (flags == SECVAR_FLAG_PRIORITY) {
+		if (flags & SECVAR_FLAG_PRIORITY) {
 			target = secboot_serialize_priority(target, node, end);
 			if (!target)
 				return OPAL_EMPTY;

--- a/libstb/secvar/storage/secboot_tpm.h
+++ b/libstb/secvar/storage/secboot_tpm.h
@@ -11,7 +11,8 @@
 #define SECBOOT_MAGIC_NUMBER	0x5053424b
 #define SECBOOT_VERSION		1
 
-#define SECBOOT_TPMNV_INDEX	0x01c10191
+#define SECBOOT_TPMNV_VARS_INDEX	0x01c10190
+#define SECBOOT_TPMNV_CONTROL_INDEX	0x01c10191
 
 struct secboot_header {
 	uint32_t magic_number;
@@ -25,11 +26,15 @@ struct secboot {
 	char update[SECBOOT_UPDATE_BANK_SIZE];
 } __attribute__((packed));
 
-struct tpmnv {
+struct tpmnv_vars {
+	struct secboot_header header;
+	char vars[0];
+} __attribute__((packed));
+
+struct tpmnv_control {
 	struct secboot_header header;
 	uint8_t active_bit;
 	char bank_hash[SECBOOT_VARIABLE_BANK_NUM][32]; // TODO: set to hashalg size?
-	char priority_var[0]; 	// Storage for one high-priority variable (e.g. PK in edk2)
 } __attribute__((packed));
 
 struct tpmnv_ops_s {

--- a/libstb/secvar/storage/secboot_tpm.h
+++ b/libstb/secvar/storage/secboot_tpm.h
@@ -7,6 +7,9 @@
 
 #define SECBOOT_VARIABLE_BANK_NUM	2
 
+/* Because mbedtls doesn't define this? */
+#define SHA256_DIGEST_LENGTH	32
+
 /* 0x5053424b = "PSBK" or Power Secure Boot Keystore */
 #define SECBOOT_MAGIC_NUMBER	0x5053424b
 #define SECBOOT_VERSION		1
@@ -34,7 +37,7 @@ struct tpmnv_vars {
 struct tpmnv_control {
 	struct secboot_header header;
 	uint8_t active_bit;
-	char bank_hash[SECBOOT_VARIABLE_BANK_NUM][32]; // TODO: set to hashalg size?
+	char bank_hash[SECBOOT_VARIABLE_BANK_NUM][SHA256_DIGEST_LENGTH];
 } __attribute__((packed));
 
 struct tpmnv_ops_s {

--- a/libstb/secvar/test/Makefile.check
+++ b/libstb/secvar/test/Makefile.check
@@ -6,6 +6,8 @@ SECVAR_TEST_DIR = libstb/secvar/test
 SECVAR_TEST = $(patsubst %.c, %, $(wildcard $(SECVAR_TEST_DIR)/secvar-test-*.c))
 
 HOSTCFLAGS+=-I . -I include -I libstb/tss2 -I libstb/tss2/ibmtpm20tss/utils
+# Needed because x86 and POWER disagree on the type for uint64_t, causes printf issues
+HOSTCFLAGS+= -Wno-format
 
 .PHONY : secvar-check
 secvar-check: $(SECVAR_TEST:%=%-check) $(SECVAR_TEST:%=%-gcov-run)


### PR DESCRIPTION
A lot of general cleanups and fixes for `secboot_tpm`.

In summary:
 - Added a lot more comments
 - Added actual size sanity checks when loaded (probably shouldn't happen, but we should probably check)
 - Added some log verbosity
 - Cleaned up some offset calculations for writing TPM, still debating macroizing or adding a helper function
 - Added some helper functions to reduce indent level
 - Added support for writing multiple priority variables to a seperate TPM NV index
 - Bank hashes and active bit are now in their own "control" NV index