### PR TITLE
Adjust `secvar_main` flow for properly writing and locking

### DIFF
--- a/libstb/secvar/backend/edk2-compat.c
+++ b/libstb/secvar/backend/edk2-compat.c
@@ -123,6 +123,11 @@ static int edk2_compat_process(void)
 		}
 	}
 
+	/* Return early if we have no updates to process */
+	if (list_empty(&update_bank)) {
+		return OPAL_EMPTY;
+	}
+
 	/* Loop through each command in the update bank.
 	 * If any command fails, it just loops out of the update bank.
 	 * It should also clear the update bank.

--- a/libstb/secvar/secvar_main.c
+++ b/libstb/secvar/secvar_main.c
@@ -110,6 +110,7 @@ int secvar_main(struct secvar_storage_driver storage_driver,
 fail:
 	secvar_set_status("fail");
 out:
+	secvar_storage.lock();
 	prerror("secvar failed to initialize, rc = %04x\n", rc);
 	return rc;
 }

--- a/libstb/secvar/secvar_main.c
+++ b/libstb/secvar/secvar_main.c
@@ -83,7 +83,12 @@ int secvar_main(struct secvar_storage_driver storage_driver,
 		rc = secvar_storage.write_bank(&variable_bank, SECVAR_VARIABLE_BANK);
 		if (rc)
 			goto out;
-
+	}
+	/* Write (and probably clear) the update bank if .process() actually detected
+	 * and handled updates in the update bank. Unlike above, this includes error
+	 * cases, where the backend should probably be clearing the bank.
+	 */
+	if (rc != OPAL_EMPTY) {
 		rc = secvar_storage.write_bank(&update_bank, SECVAR_UPDATE_BANK);
 		if (rc)
 			goto out;


### PR DESCRIPTION
This PR contains three simple changes to make the storage writing flow slightly more correct:
 - the update bank is written to if `.process()` returns anything other than `OPAL_EMPTY`
 - the storage driver is locked on any error condition
 - the edk2 driver's `.process()` now early-returns `OPAL_EMPTY` if the list is empty