### PR TITLE
Define three failure cases/states in main secvar initialization

### DIFF
--- a/libstb/secvar/backend/edk2-compat.c
+++ b/libstb/secvar/backend/edk2-compat.c
@@ -123,6 +123,11 @@ static int edk2_compat_process(void)
 		}
 	}
 
+	/* Return early if we have no updates to process */
+	if (list_empty(&update_bank)) {
+		return OPAL_EMPTY;
+	}
+
 	/* Loop through each command in the update bank.
 	 * If any command fails, it just loops out of the update bank.
 	 * It should also clear the update bank.

--- a/libstb/secvar/secvar_main.c
+++ b/libstb/secvar/secvar_main.c
@@ -110,6 +110,7 @@ int secvar_main(struct secvar_storage_driver storage_driver,
 fail:
 	secvar_set_status("fail");
 out:
+	secvar_storage.lock();
 	prerror("secvar failed to initialize, rc = %04x\n", rc);
 	return rc;
 }

--- a/libstb/secvar/secvar_main.c
+++ b/libstb/secvar/secvar_main.c
@@ -83,7 +83,12 @@ int secvar_main(struct secvar_storage_driver storage_driver,
 		rc = secvar_storage.write_bank(&variable_bank, SECVAR_VARIABLE_BANK);
 		if (rc)
 			goto out;
-
+	}
+	/* Write (and probably clear) the update bank if .process() actually detected
+	 * and handled updates in the update bank. Unlike above, this includes error
+	 * cases, where the backend should probably be clearing the bank.
+	 */
+	if (rc != OPAL_EMPTY) {
 		rc = secvar_storage.write_bank(&update_bank, SECVAR_UPDATE_BANK);
 		if (rc)
 			goto out;


### PR DESCRIPTION
There should be three failure modes for secvar initialization:
 - Early failure
 - Hard failure
 - Soft failure
---
Early failures occur if we cannot load variables at all from storage -- this sets the `secvar/status` DT node to `"fail"`, which should cause loads of problems for everything later in the stack. This failure state also attempts to lock the storage driver. If this too fails, we jump into the next failure type

---

Hard failures occur when:
 - we cannot lock the storage bank
 - we cannot create the `secvar` DT node
 - we cannot create the `os-secure-enforcing` property

If any of these events happen, we immediately cease the booting process.

---

Soft failures occur when:
 - the backend's `.pre_process()` or `.post_process()` hook returns an error
 - we fail to write to either the variable OR update bank

If any of these events happen, we force the bootloader to cease the boot by setting the `os-secure-enforcing` property, but clearing all banks -- thus making a secure boot impossible. We also attempt to lock the storage driver, which should halt on failure.