### PR TITLE
Move physical presence checks and resets to the storage driver

### DIFF
--- a/include/secvar.h
+++ b/include/secvar.h
@@ -17,11 +17,14 @@ struct secvar_storage_driver {
 };
 
 struct secvar_backend_driver {
-	int (*pre_process)(void);               // Perform any pre-processing stuff (e.g. determine secure boot state)
-	int (*process)(void);                   // Process all updates
-	int (*post_process)(void);              // Perform any post-processing stuff (e.g. derive/update variables)
-	int (*validate)(struct secvar *var);    // Validate a single variable, return boolean
-	const char *compatible;			// String to use for compatible in secvar node
+	int (*pre_process)(struct list_head *variable_bank,
+			   struct list_head *update_bank);   // Perform any pre-processing stuff (e.g. determine secure boot state)
+	int (*process)(struct list_head *variable_bank,
+		       struct list_head *update_bank);       // Process all updates
+	int (*post_process)(struct list_head *variable_bank,
+			    struct list_head *update_bank);  // Perform any post-processing stuff (e.g. derive/update variables)
+	int (*validate)(struct secvar *var);		     // Validate a single variable, return boolean
+	const char *compatible;				     // String to use for compatible in secvar node
 };
 
 extern struct secvar_storage_driver secboot_tpm_driver;

--- a/libstb/secvar/backend/edk2-compat-process.c
+++ b/libstb/secvar/backend/edk2-compat-process.c
@@ -286,15 +286,7 @@ int validate_esl_list(char *key, char *esl, size_t size)
 /* Get the timestamp for the last update of the give key */
 static struct efi_time *get_last_timestamp(const char *key, char *last_timestamp)
 {
-	//struct secvar_node *node;
-	//char *timestamp_list;
 	u8 off;
-
-//	node = find_secvar("TS", 3, bank);
-
-	/* We cannot find timestamp variable, did someone tamper it ? */
-//	if (!node)
-//		return NULL;
 
 	if (!last_timestamp)
 		return NULL;
@@ -309,10 +301,6 @@ static struct efi_time *get_last_timestamp(const char *key, char *last_timestamp
 		off = 3;
 	else
 		return NULL;
-
-//	timestamp_list = node->var->data;
-//	if (!timestamp_list)
-//		return NULL;
 
 	return &((struct efi_time *)last_timestamp)[off];
 }

--- a/libstb/secvar/backend/edk2-compat-process.h
+++ b/libstb/secvar/backend/edk2-compat-process.h
@@ -33,7 +33,7 @@ extern struct list_head staging_bank;
 
 /* Update the variable in the variable bank with the new value. */
 int update_variable_in_bank(struct secvar *secvar, const char *data,
-			    uint64_t dsize);
+			    uint64_t dsize, struct list_head *bank);
 
 /* This function outputs the Authentication 2 Descriptor in the
  * auth_buffer and returns the size of the buffer. Please refer to
@@ -45,16 +45,17 @@ int get_auth_descriptor2(void *buf, size_t buflen, char **auth_buffer);
 int validate_esl_list(char *key, char *esl, size_t size);
 
 /* Update the TS variable with the new timestamp */
-int update_timestamp(char *key, struct efi_time *timestamp);
+int update_timestamp(char *key, struct efi_time *timestamp, char *last_timestamp);
 
 /* Check the new timestamp against the timestamp last update was done */
-int check_timestamp(char *key, struct efi_time *timestamp);
+int check_timestamp(char *key, struct efi_time *timestamp, char *last_timestamp);
 
 /* Check the GUID of the data type */
 bool is_pkcs7_sig_format(void *data);
 
 /* Process the update */
 int process_update(struct secvar_node *update, char **newesl, int *neweslsize,
-		   struct efi_time *timestamp);
+		   struct efi_time *timestamp, struct list_head *bank,
+		   char *last_timestamp);
 
 #endif

--- a/libstb/secvar/backend/edk2-compat-reset.c
+++ b/libstb/secvar/backend/edk2-compat-reset.c
@@ -42,21 +42,6 @@ int reset_keystore(struct list_head *bank)
 	return rc;
 }
 
-bool is_physical_presence_asserted(void)
-{
-	struct dt_node *secureboot;
-
-	secureboot = dt_find_by_path(dt_root, "ibm,secureboot");
-	if (!secureboot)
-		return false;
-
-	if (dt_find_property(secureboot, "clear-os-keys")
-			|| dt_find_property(secureboot, "clear-all-keys")
-			|| dt_find_property(secureboot, "clear-mfg-keys"))
-		return true;
-
-	return false;
-}
 
 int add_hw_key_hash(struct list_head *bank)
 {

--- a/libstb/secvar/backend/edk2-compat-reset.c
+++ b/libstb/secvar/backend/edk2-compat-reset.c
@@ -6,38 +6,38 @@
 #include "edk2-compat-reset.h"
 #include "../secvar.h"
 
-int reset_keystore(void)
+int reset_keystore(struct list_head *bank)
 {
 	struct secvar_node *node;
 	int rc = 0;
 
-	node = find_secvar("PK", 3, &variable_bank);
+	node = find_secvar("PK", 3, bank);
 	if (node)
-		rc = update_variable_in_bank(node->var, NULL, 0);
+		rc = update_variable_in_bank(node->var, NULL, 0, bank);
 	if (rc)
 		return rc;
 
-	node = find_secvar("KEK", 4, &variable_bank);
+	node = find_secvar("KEK", 4, bank);
 	if (node)
-		rc = update_variable_in_bank(node->var, NULL, 0);
+		rc = update_variable_in_bank(node->var, NULL, 0, bank);
 	if (rc)
 		return rc;
 
-	node = find_secvar("db", 3, &variable_bank);
+	node = find_secvar("db", 3, bank);
 	if (node)
-		rc = update_variable_in_bank(node->var, NULL, 0);
+		rc = update_variable_in_bank(node->var, NULL, 0, bank);
 	if (rc)
 		return rc;
 
-	node = find_secvar("dbx", 4, &variable_bank);
+	node = find_secvar("dbx", 4, bank);
 	if (node)
-		rc = update_variable_in_bank(node->var, NULL, 0);
+		rc = update_variable_in_bank(node->var, NULL, 0, bank);
 	if (rc)
 		return rc;
 
-	node = find_secvar("TS", 3, &variable_bank);
+	node = find_secvar("TS", 3, bank);
 	if (node)
-		rc = update_variable_in_bank(node->var, NULL, 0);
+		rc = update_variable_in_bank(node->var, NULL, 0, bank);
 
 	return rc;
 }
@@ -58,7 +58,7 @@ bool is_physical_presence_asserted(void)
 	return false;
 }
 
-int add_hw_key_hash(void)
+int add_hw_key_hash(struct list_head *bank)
 {
 	struct secvar_node *node;
 	uint32_t hw_key_hash_size;
@@ -78,21 +78,21 @@ int add_hw_key_hash(void)
 
 	node = new_secvar("HWKH", 5, hw_key_hash,
 			hw_key_hash_size, SECVAR_FLAG_PRIORITY);
-	list_add_tail(&variable_bank, &node->link);
+	list_add_tail(bank, &node->link);
 
 	return OPAL_SUCCESS;
 }
 
-int delete_hw_key_hash(void)
+int delete_hw_key_hash(struct list_head *bank)
 {
 	struct secvar_node *node;
 	int rc;
 
-	node = find_secvar("HWKH", 5, &variable_bank);
+	node = find_secvar("HWKH", 5, bank);
 	if (!node)
 		return OPAL_SUCCESS;
 
-	rc = update_variable_in_bank(node->var, NULL, 0);
+	rc = update_variable_in_bank(node->var, NULL, 0, bank);
 	return rc;
 }
 

--- a/libstb/secvar/backend/edk2-compat-reset.h
+++ b/libstb/secvar/backend/edk2-compat-reset.h
@@ -9,7 +9,7 @@
 #endif
 
 /* clear all os keys and the timestamp*/
-int reset_keystore(void);
+int reset_keystore(struct list_head *bank);
 
 /* Check if physical presence is asserted */
 bool is_physical_presence_asserted(void);
@@ -19,9 +19,9 @@ bool is_physical_presence_asserted(void);
 int verify_hw_key_hash(void);
 
 /* Adds hw-key-hash */
-int add_hw_key_hash(void);
+int add_hw_key_hash(struct list_head *bank);
 
 /* Delete hw-key-hash */
-int delete_hw_key_hash(void);
+int delete_hw_key_hash(struct list_head *bank);
 
 #endif

--- a/libstb/secvar/backend/edk2-compat-reset.h
+++ b/libstb/secvar/backend/edk2-compat-reset.h
@@ -11,9 +11,6 @@
 /* clear all os keys and the timestamp*/
 int reset_keystore(struct list_head *bank);
 
-/* Check if physical presence is asserted */
-bool is_physical_presence_asserted(void);
-
 /* Compares the hw-key-hash from device tree to the value stored in
  * the protected storage to ensure it is not modified */
 int verify_hw_key_hash(void);

--- a/libstb/secvar/backend/edk2-compat.c
+++ b/libstb/secvar/backend/edk2-compat.c
@@ -156,7 +156,8 @@ static int edk2_compat_process(struct list_head *variable_bank,
 	              	break;
 		}
 
-		rc = process_update(node, &newesl, &neweslsize, &timestamp, &staging_bank, tsvar->var->data);
+		rc = process_update(node, &newesl, &neweslsize, &timestamp, &staging_bank,
+				    tsvar->var->data);
 		if (rc)
 			break;
 

--- a/libstb/secvar/backend/edk2-compat.c
+++ b/libstb/secvar/backend/edk2-compat.c
@@ -105,16 +105,6 @@ static int edk2_compat_process(struct list_head *variable_bank,
 
 	prlog(PR_INFO, "Setup mode = %d\n", setup_mode);
 
-	/* Check if physical presence is asserted */
-	if (is_physical_presence_asserted()) {
-		prlog(PR_INFO, "Physical presence asserted to clear OS Secure boot keys\n");
-		rc = reset_keystore(variable_bank);
-		if (rc)
-			goto cleanup;
-		setup_mode = true;
-		goto cleanup;
-	}
-
 	/* Check HW-KEY-HASH */
 	if (!setup_mode) {
 		rc = verify_hw_key_hash();

--- a/libstb/secvar/secvar_devtree.c
+++ b/libstb/secvar/secvar_devtree.c
@@ -64,3 +64,18 @@ void secvar_set_update_status(uint64_t val)
 	dt_add_property_u64(secvar_node, "update-status", val);
 }
 
+bool secvar_check_physical_presence(void)
+{
+	struct dt_node *secureboot;
+
+	secureboot = dt_find_by_path(dt_root, "ibm,secureboot");
+	if (!secureboot)
+		return false;
+
+	if (dt_find_property(secureboot, "clear-os-keys")
+			|| dt_find_property(secureboot, "clear-all-keys")
+			|| dt_find_property(secureboot, "clear-mfg-keys"))
+		return true;
+
+	return false;
+}

--- a/libstb/secvar/secvar_devtree.h
+++ b/libstb/secvar/secvar_devtree.h
@@ -10,4 +10,6 @@ void secvar_init_devnode(const char *compatible);
 void secvar_set_status(const char *status);
 void secvar_set_update_status(uint64_t val);
 
+bool secvar_check_physical_presence(void);
+
 #endif

--- a/libstb/secvar/secvar_main.c
+++ b/libstb/secvar/secvar_main.c
@@ -57,7 +57,7 @@ int secvar_main(struct secvar_storage_driver storage_driver,
 	secvar_set_status("okay");
 
 	if (secvar_backend.pre_process) {
-		rc = secvar_backend.pre_process();
+		rc = secvar_backend.pre_process(&variable_bank, &update_bank);
 		if (rc) {
 			prlog(PR_ERR, "Error in backend pre_process = %d\n", rc);
 			/* Early failure state, lock the storage */
@@ -71,7 +71,7 @@ int secvar_main(struct secvar_storage_driver storage_driver,
 		goto out;
 
 	/* Process variable updates from the update bank. */
-	rc = secvar_backend.process();
+	rc = secvar_backend.process(&variable_bank, &update_bank);
 
 	/* Create and set the ibm,opal/secvar/update-status device tree property */
 	secvar_set_update_status(rc);
@@ -97,7 +97,7 @@ int secvar_main(struct secvar_storage_driver storage_driver,
 	secvar_storage.lock();
 
 	if (secvar_backend.post_process) {
-		rc = secvar_backend.post_process();
+		rc = secvar_backend.post_process(&variable_bank, &update_bank);
 		if (rc) {
 			prlog(PR_ERR, "Error in backend post_process = %d\n", rc);
 			goto out;

--- a/libstb/secvar/test/secvar-test-edk2-compat.c
+++ b/libstb/secvar/test/secvar-test-edk2-compat.c
@@ -28,10 +28,10 @@
 #include "./data/multipleDB.h"
 #include "./data/multiplePK.h"
 
-int reset_keystore(void) { return 0; }
+int reset_keystore(struct list_head *bank __unused) { return 0; }
 bool is_physical_presence_asserted(void) { return 0; }
-int add_hw_key_hash(void) { return 0; }
-int delete_hw_key_hash(void) { return 0; }
+int add_hw_key_hash(struct list_head *bank __unused) { return 0; }
+int delete_hw_key_hash(struct list_head *bank __unused) { return 0; }
 int verify_hw_key_hash(void) { return 0; }
 
 const char *secvar_test_name = "edk2-compat";
@@ -53,7 +53,7 @@ int run_test()
 
 	// Check pre-process creates the empty variables
 	ASSERT(0 == list_length(&variable_bank));
-	rc = edk2_compat_pre_process();
+	rc = edk2_compat_pre_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS == rc);
 	ASSERT(5 == list_length(&variable_bank));
 	tmp = find_secvar("TS", 3, &variable_bank);
@@ -73,7 +73,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS == rc);
 	ASSERT(5 == list_length(&variable_bank));
 	ASSERT(0 == list_length(&update_bank));
@@ -95,7 +95,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	printf("rc is %d %04x\n", rc, rc);
 	ASSERT(OPAL_SUCCESS != rc);
 	ASSERT(5 == list_length(&variable_bank));
@@ -116,7 +116,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS == rc);
 	ASSERT(5 == list_length(&variable_bank));
 	ASSERT(0 == list_length(&update_bank));
@@ -135,7 +135,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_PERMISSION == rc);
 	ASSERT(5 == list_length(&variable_bank));
 	ASSERT(0 == list_length(&update_bank));
@@ -155,7 +155,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS == rc);
 	ASSERT(5 == list_length(&variable_bank));
 	ASSERT(0 == list_length(&update_bank));
@@ -176,7 +176,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_PERMISSION == rc);
 
 	// Add invalid KEK, .process(), should fail
@@ -191,7 +191,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS != rc);
 	ASSERT(5 == list_length(&variable_bank));
 	ASSERT(0 == list_length(&update_bank));
@@ -211,7 +211,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS != rc);
 	ASSERT(5 == list_length(&variable_bank));
 	ASSERT(0 == list_length(&update_bank));
@@ -230,7 +230,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS == rc);
 	ASSERT(5 == list_length(&variable_bank));
 	ASSERT(0 == list_length(&update_bank));
@@ -249,7 +249,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS == rc);
 	ASSERT(5 == list_length(&variable_bank));
 	ASSERT(0 == list_length(&update_bank));
@@ -268,7 +268,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS == rc);
 	ASSERT(5 == list_length(&variable_bank));
 	ASSERT(0 == list_length(&update_bank));
@@ -288,7 +288,7 @@ int run_test()
 	list_add_tail(&update_bank, &tmp->link);
 	ASSERT(1 == list_length(&update_bank));
 
-	rc = edk2_compat_process();
+	rc = edk2_compat_process(&variable_bank, &update_bank);
 	ASSERT(OPAL_SUCCESS != rc);
 
 	return 0;

--- a/libstb/secvar/test/secvar-test-edk2-compat.c
+++ b/libstb/secvar/test/secvar-test-edk2-compat.c
@@ -29,7 +29,6 @@
 #include "./data/multiplePK.h"
 
 int reset_keystore(struct list_head *bank __unused) { return 0; }
-bool is_physical_presence_asserted(void) { return 0; }
 int add_hw_key_hash(struct list_head *bank __unused) { return 0; }
 int delete_hw_key_hash(struct list_head *bank __unused) { return 0; }
 int verify_hw_key_hash(void) { return 0; }

--- a/libstb/secvar/test/secvar-test-secboot-tpm.c
+++ b/libstb/secvar/test/secvar-test-secboot-tpm.c
@@ -40,6 +40,19 @@ int tss_get_defined_nv_indices(TPMI_RH_NV_INDEX **indices, size_t *count)
 	return 0;
 }
 
+int tss_nv_undefine_space(TPMI_RH_NV_INDEX index)
+{
+	(void) index;
+	return 0;
+}
+
+/* Toggle this to test the physical presence resetting */
+bool phys_presence = false;
+bool secvar_check_physical_presence(void)
+{
+	return phys_presence;
+}
+
 struct platform platform;
 
 int run_test(void)


### PR DESCRIPTION
At the moment, physical presence resets handled in the backend are only reached if we successfully initialize most of secvar already, when there are possible problems that can be rectified earlier.

In short, we may not be able to reset secure boot state if:
 - NV indices contain garbage (corrected by a format)
 - Only one NV index defined for some reason (corrected by redefinition)

This changes the physical presence behavior to instead undefine the NV indices. This should cause them to be immediately redefined, causing a full reformat. This is essentially the same behavior as the previous approach (resets all variables and enters set-up mode), and now should allow recovering from a few additional NV error cases.